### PR TITLE
fix: disable husky

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,7 @@
 name: main
 on: [push, pull_request]
+env:
+  HUSKY: 0
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![NPM version][npm-image]][npm-url]
 [![NPM download][download-image]][download-url]
-[![codebeat badge](https://codebeat.co/badges/93d238e4-31cc-4865-80b6-8b6d4695c249)](https://codebeat.co/projects/github-com-node-casbin-casbin-mongo-changestream-watcher-master)
-[![Coverage Status](https://coveralls.io/repos/github/node-casbin/casbin-mongo-changestream-watcher/badge.svg?branch=master)](https://coveralls.io/repos/github/node-casbin/casbin-mongo-changestream-watcher?branch=master)
+[![codebeat badge](https://codebeat.co/badges/6a941388-2e36-408b-952e-2bd227e3997c)](https://codebeat.co/projects/github-com-node-casbin-mongo-changestream-watcher-master)
+[![Coverage Status](https://coveralls.io/repos/github/node-casbin/mongo-changestream-watcher/badge.svg?branch=master)](https://coveralls.io/github/node-casbin/mongo-changestream-watcher?branch=master)
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/casbin/lobby)
 [![tests](https://github.com/node-casbin/casbin-mongo-changestream-watcher/actions/workflows/main.yml/badge.svg)](https://github.com/node-casbin/casbin-mongo-changestream-watcher/actions/workflows/main.yml)
 


### PR DESCRIPTION
@hsluoyz Enable codebeat by logging into [codebeat.co](https://codebeat.co/) and add mongo-changestream-watcher there. I cannot since I do not have a repository admin role.

Need to double check that the codebeat badge is also correct. I updated code coverage to the correct one and it should be now working. However I think you need to enable [coveralls.io](https://docs.coveralls.io/coveralls-notifications) from their website for it to be directly available in the pull requests.

Fix: https://github.com/node-casbin/mongo-changestream-watcher/issues/2
